### PR TITLE
Update for deprecated behavior kaiko.py

### DIFF
--- a/kaiko/kaiko.py
+++ b/kaiko/kaiko.py
@@ -293,7 +293,7 @@ class Trades(KaikoData):
 
     @staticmethod
     def df_formatter(res, extra_args: dict = {}):
-        df = pd.DataFrame(res['data'], dtype = 'float')
+        df = pd.DataFrame(res['data'], dtype={'price': float, 'amount': float})
         df.set_index('timestamp', inplace=True)
         df.index = ut.convert_timestamp_unix_to_datetime(df.index)
         return df


### PR DESCRIPTION
FutureWarning: Could not cast to float64, falling back to object. This behavior is deprecated. In a future version, when a dtype is passed to 'DataFrame', either all columns will be cast to that dtype, or a TypeError will be raised.
